### PR TITLE
fixed a typo in aiff.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+docs/
+build/

--- a/audiotools/aiff.py
+++ b/audiotools/aiff.py
@@ -284,8 +284,8 @@ class AIFF_File_Chunk(AIFF_Chunk):
 
         from audiotools import LimitedFileReader
 
-        self.__wav_file__.seek(self.__offset__)
-        return LimitedFileReader(self.__wav_file__, self.size())
+        self.__aiff_file__.seek(self.__offset__)
+        return LimitedFileReader(self.__aiff_file__, self.size())
 
     def verify(self):
         """returns True if chunk size matches chunk's data"""


### PR DESCRIPTION
There was a typo in aiff.py that was blocking attempts to retrieve metadata from an aiff file.

Lossless audio files can include metadata even though it is uncommon. It is a little easier to force this data on an aiff file than it is wav file. Audiotools' built in get_metadata() will pull this metadata if it exists regardless of audio type.

Prior to this change I received this error:

```
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/Users/michael/.virtualenvs/env4/lib/python2.7/site-packages/audiotools/aiff.py", line 690, in get_metadata
    return ID3v22Comment.parse(BitstreamReader(chunk.data(), 0))
  File "/Users/michael/.virtualenvs/env4/lib/python2.7/site-packages/audiotools/aiff.py", line 287, in data
    self.__wav_file__.seek(self.__offset__)
AttributeError: 'AIFF_File_Chunk' object has no attribute '__wav_file__'
```
