### PR TITLE
flac: fix reading of some cdrdao embedded TOC files

### DIFF
--- a/audiotools/flac.py
+++ b/audiotools/flac.py
@@ -1820,10 +1820,11 @@ class FlacAudio(WaveContainer, AiffContainer):
                 except SheetException:
                     pass
             if u"CDTOC" in vorbiscomment:
-                from audiotools.cdtoc import CDTOC
+                from audiotools import SheetException
+                from audiotools.toc import read_tocfile_string
                 try:
-                    return CDTOC.from_unicode(vorbiscomment[u"CDTOC"][0])
-                except ValueError:
+                    return read_tocfile_string(vorbiscomment[u"CDTOC"][0])
+                except SheetException:
                     pass
         except IndexError:
             pass


### PR DESCRIPTION
this is fixed by reading them the same way trackverify does when it
takes it from an external TOC file. otherwise, i encounter a situation
in which the embedded version does not work while the external one does
even though they are identical. perhaps this is because my TOC has
metadata information (CDTEXT)?