### PR TITLE
Fix version check of Urwid

### DIFF
--- a/audiotools/ui.py
+++ b/audiotools/ui.py
@@ -52,7 +52,7 @@ def choice_selection_unicode(metadata):
 try:
     import urwid
 
-    if urwid.version.VERSION < (1, 0, 0):
+    if urwid.VERSION < (1, 0, 0):
         raise ImportError()
 
     def Screen():


### PR DESCRIPTION
Urwid used to provide `VERSION` both in its main namespace (`urwid.VERSION`) and under `version` (`urwid.version.VERSION`), but as of [commit 8d8e4b678cc0f93149a4a964b26ee11fb136ea0f](https://github.com/urwid/urwid/commit/8d8e4b678cc0f93149a4a964b26ee11fb136ea0f) this is now [only available in the main namespace](https://github.com/urwid/urwid/commit/8d8e4b678cc0f93149a4a964b26ee11fb136ea0f#diff-622c6cdaa0aebea827e82ba7a1e6127f21fe51c58ff6a88ff6b018c3885ea2e9L105-R217), as [setuptools-scm does not include `VERSION` in its generated `version.py`](https://github.com/pypa/setuptools_scm/blob/main/src/setuptools_scm/_integration/dump_version.py). This breaks audiotools with urwid>=2.2.0 (2023-09-21).

The simple fix is to just look at `urwid.VERSION` instead of `urwid.version.VERSION`, which is what this patch does.